### PR TITLE
fixed state code issue with non-US countries

### DIFF
--- a/src/components/EventCard.js
+++ b/src/components/EventCard.js
@@ -25,7 +25,13 @@ function EventCard(event) {
   const formatTime = moment(date).format("h:mm A");
   const venueName = event.event._embedded.venues[0].name;
   const city = event.event._embedded.venues[0].city.name;
-  const state = event.event._embedded.venues[0].country.name;
+  const country = event.event._embedded.venues[0].country.name;
+  let state;
+  if(country == "United States Of America"){
+    state = event.event._embedded.venues[0].state.stateCode;
+  } else {
+    state = "";
+  }
 
 
   return (
@@ -33,8 +39,8 @@ function EventCard(event) {
       <img className="card-img-top" src={imageUrl} alt="Card image cap" />
       <div className="card-body">
         <h5 className="card-title">{event.event.name}</h5>
-        <p className="card-text">{city+","}</p>
-        <p className="card-text">{state}</p>
+        <p className="card-text">{city+", " + state}</p>
+        <p className="card-text">{country}</p>
       </div>
       <ul className="list-group list-group-flush">
         <li className="list-group-item">{venueName}</li>


### PR DESCRIPTION
App would crash previously when trying to get "stateCode" value when events were in non-US countries. These countries did not have "stateCode" key. Used an if statement to check if the event's country is US, then display city and state. If not, then only display city and country.  